### PR TITLE
Add required metadata for crates.io publication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,11 @@
 name = "gtd-mcp"
 version = "0.3.0"
 edition = "2024"
+description = "A Model Context Protocol (MCP) server for GTD (Getting Things Done) task management"
+license = "MIT"
+repository = "https://github.com/ekicyou/gtd-mcp-rs"
+keywords = ["mcp", "gtd", "task-management", "productivity"]
+categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
 mcp-attr = "0.0.7"


### PR DESCRIPTION
Adds the required metadata fields to Cargo.toml for publishing to crates.io:

- description: Project description
- license: MIT
- repository: GitHub repository URL
- keywords: Searchability keywords
- categories: crates.io categories

Fixes the 400 Bad Request error when running cargo publish.